### PR TITLE
Fetch the thermostat attributes before updating

### DIFF
--- a/apps/thermostats-update/thermostats-update.py
+++ b/apps/thermostats-update/thermostats-update.py
@@ -195,7 +195,7 @@ class ThermostatsUpdate(hass.Hass):
             "Updating state and current temperature for {}...".format(entity),
             self.log_level,
         )
-        attrs = {}
+        attrs = self.get_state(entity, attribute="all")["attributes"]
         if not self.state_only:
             attrs[ATTR_CURRENT_TEMP] = current_temp
         if not self.temp_only:


### PR DESCRIPTION
With Appdaemon 4 the attributes of the thermostats keeps reseting when using set_state. This might be a bug ( https://github.com/home-assistant/appdaemon/issues/904 ) but this workaround fixes it