### PR TITLE
Fix for google home sync : current_temp is reported as string instead of float

### DIFF
--- a/apps/thermostats-update/thermostats-update.py
+++ b/apps/thermostats-update/thermostats-update.py
@@ -197,7 +197,7 @@ class ThermostatsUpdate(hass.Hass):
         )
         attrs = self.get_state(entity, attribute="all")["attributes"]
         if not self.state_only:
-            attrs[ATTR_CURRENT_TEMP] = current_temp
+            attrs[ATTR_CURRENT_TEMP] = float(current_temp)
         if not self.temp_only:
             state = self.find_thermostat_state(float(target_temp))
             attrs[ATTR_HVAC_MODE] = state


### PR DESCRIPTION
Avoid  climate not syncing correctly and throwing this error
```
2021-07-08 22:21:05 ERROR (MainThread) [homeassistant.components.google_assistant.smart_home] Unexpected error serializing query for <state climate.radiateur_cuisine=heat; hvac_modes=['heat', 'off'], min_temp=10, max_temp=28, current_temperature=28.0, temperature=28, friendly_name=radiateur_cuisine, supported_features=1, hvac_mode=heat @ 2021-07-08T22:16:58.122891+02:00>
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/google_assistant/smart_home.py", line 143, in async_devices_query
    devices[devid] = entity.query_serialize()
  File "/usr/src/homeassistant/homeassistant/components/google_assistant/helpers.py", line 550, in query_serialize
    deep_update(attrs, trt.query_attributes())
  File "/usr/src/homeassistant/homeassistant/components/google_assistant/trait.py", line 831, in query_attributes
    response["thermostatTemperatureAmbient"] = round(
TypeError: type str doesn't define __round__ method
```